### PR TITLE
Option to read the account number interactively

### DIFF
--- a/wg-mullvad.py
+++ b/wg-mullvad.py
@@ -291,10 +291,9 @@ def main():
             description=f'{__file__}',
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    required = parser.add_argument_group('required arguments')
-    required.add_argument(
-            '--account', dest='account_number', type=validate_account,
-            action='store', required=True, help='mullvad account number')
+    parser.add_argument(
+        '--account', dest='account_number', type=validate_account,
+        action='store', help='mullvad account number')
 
     parser.add_argument(
         '--settings-file', dest='settings_file', action='store',
@@ -323,6 +322,8 @@ def main():
     args = parser.parse_args()
 
     try:
+        if not args.account_number:
+            args.account_number = validate_account(input('Account number: '))
         mullvad = Mullvad(args)
         mullvad.run()
     except Exception as e:


### PR DESCRIPTION
# Problem Statement
Providing the account number as a command-line argument means it may be logged as part of shell history.
Given that the number is sensitive information, currently the tool risks unexpected use of the account.

# Change Summary
This change adds the option to provide the account number through an interactive prompt, after the tool starts executing.

# Change Details
1. Make the `--account` argument optional
2. Prompt the user for their account number if `args.account_number` is missing