### PR TITLE
Add more filtering cretiria for WireGuard relays

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,43 @@
 
 This repository contains a python script that generates WireGuard®[^1] configuration files for all Mullvad relays.
 
-Use --help to see how to use it.
-
 The script can generate, save and reuse a private key when generating configurations.
+
+## User guide:
+There are some builtin functions to help the user: To see all options use **--help**.
+
+### Settings file
+If the **--settings-file** does not exist it will be created, and a private key for WireGuard will be generated.
+Everytime the program is executed, it will login to the account and check that the device exists. If not it will try to create it. Any file in ini format that contains a "privatekey"-entry is a valid settings file. Even an existing configuration file can be used as a settings file as long as it contains the private key.
+
+### Filter
+**--filter** is an option to limit the number of files that will be edited or created. The filter search will match any hostname that contains the given term. **--filter se-got** would generate files for all relays in Gothenburg Sweden. Standard name scheme for relays are: **\<country-city-type-identifier>**.
+
+### Multihop
+**--multihop-server** has a built in search. If the specified term does not respond to exactly 1 server, it will show the servers matching the search term. Example: **--multihop-server se-got** will show all the possible multihop-servers in Gothenburg Sweden. **--multihop-server se-got-wg-001** would set this server as multihop server in all configurations.
+
+### Files and Folders
+Files will only be edited or added, never removed. If you want to start over, just remove the folder with configuration files created, e.g. **(~/.config/mullvad/wg0)**. Its also possible to run the program many times to add different setups.
+
+## Examples
+
+    # Create WireGuard files for all relays in Gothenburg:
+    ./wg-mullvad.py --account <myaccountnumber> --filter se-got
+    
+    # Create files for all relays in Stockholm
+    ./wg-mullvad.py --account <myaccountnumber> --filter se-sto
+    
+    # Create files for all servers via se-got-wg-001
+    ./wg-mullvad.py --account <myaccountnumber> --multihop-server se-got-wg-001
+    
+    # Create multihop files for servers in Stockholm via se-got-wg-003
+    ./wg-mullvad.py --account <myaccountnumber> --multihop-server se-got-wg-003 --filter se-sto
+    
+## Multihop options
+ There are 3 different ways to do multihop with mullvad.
+ 
+ 1. Multihop by using special port in WireGuard config (described above).
+ 2. Using [Socks](https://mullvad.net/en/help/different-entryexit-node-using-wireguard-and-socks5-proxy).
+ 3. Using a WireGuard tunnel in a WireGuard tunnel (requires more complex routing setup and outside the scope of this guide).
 
 [^1]: "WireGuard" is a registered trademark of Jason A. Donenfeld.

--- a/wg-mullvad.py
+++ b/wg-mullvad.py
@@ -16,24 +16,24 @@ from cryptography.hazmat.primitives import serialization
 _version = '1.1'
 
 
-def generate_publickey(privatekey):
+def generate_publickey(privatekey: str) -> str:
     private_key_bytes = base64.b64decode(privatekey)
     private_key = X25519PrivateKey.from_private_bytes(private_key_bytes)
     public_key = private_key.public_key()
     public_key_bytes = public_key.public_bytes(
         encoding=serialization.Encoding.Raw,
-        format=serialization.PublicFormat.Raw
+        format=serialization.PublicFormat.Raw,
     )
     wgpublickey = base64.b64encode(public_key_bytes).decode('utf-8')
     return wgpublickey
 
 
-def generate_privatekey():
+def generate_privatekey() -> str:
     privatekey = X25519PrivateKey.generate()
     private_key_bytes = privatekey.private_bytes(
         encoding=serialization.Encoding.Raw,
         format=serialization.PrivateFormat.Raw,
-        encryption_algorithm=serialization.NoEncryption()
+        encryption_algorithm=serialization.NoEncryption(),
     )
     wgprivatekey = base64.b64encode(private_key_bytes).decode('utf-8')
     return wgprivatekey
@@ -81,7 +81,7 @@ class Mullvad:
         if device:
             self.create_wg_configs(device, privatekey, multihop_server)
 
-    def get_privatekey(self):
+    def get_privatekey(self) -> str:
         print(f'Reading settings from: {self._settings_file}')
         self._config.read(self._settings_file)
         try:
@@ -91,7 +91,7 @@ class Mullvad:
             print('Solution: add it or remove the file completely to generate a new device')
             sys.exit(1)
 
-    def save_privatekey(self, privatekey):
+    def save_privatekey(self, privatekey) -> bool:
         self._settings_file.parent.mkdir(parents=True, exist_ok=True)
         self._settings_file.touch(mode=0o600, exist_ok=True)
         with self._settings_file.open('w') as _file:
@@ -101,18 +101,19 @@ class Mullvad:
             self._config.write(_file)
         return True
 
-    def get_webtoken(self):
+    def get_webtoken(self) -> str:
         if not self._webtoken:
             self.generate_webtoken()
         return self._webtoken
 
-    def generate_webtoken(self):
-        body = {}
-        body['account_number'] = self._account_number
+    def generate_webtoken(self) -> str:
+        body = {
+            'account_number': self._account_number,
+        }
         req = urllib.request.Request('https://api.mullvad.net/auth/v1/webtoken')
         req.add_header('Content-Type', 'application/json')
-        response = urllib.request.urlopen(req, json.dumps(body).encode()).read()
-        data = json.loads(response)
+        with urllib.request.urlopen(req, json.dumps(body).encode()) as response:
+            data = json.load(response)
         self._webtoken = data['access_token']
 
     def api(self, url, body=None):
@@ -123,17 +124,15 @@ class Mullvad:
 
         if body:
             req.add_header('Content-Type', 'application/json')
-            response = urllib.request.urlopen(req, json.dumps(body).encode())
-        else:
-            response = urllib.request.urlopen(req)
 
-        return self.get_response(response)
+        with urllib.request.urlopen(req, data=json.dumps(body).encode() if body else None) as response:
+            return self.get_response(response)
 
     def get_response(self, response):
         if response.headers.get('Content-Encoding') == 'gzip':
             data = json.loads(gzip.decompress(response.read()))
         else:
-            data = json.loads(response.read())
+            data = json.load(response)
         return data
 
     def get_device(self, publickey):
@@ -148,7 +147,7 @@ class Mullvad:
             print(f'Device is not registered: {publickey}')
             return None
         except urllib.error.HTTPError as e:
-            error_message = json.loads(e.read())
+            error_message = json.load(e)
             _code = error_message.get('code')
             _message = error_message.get('detail')
             if _message:
@@ -159,15 +158,16 @@ class Mullvad:
 
     def create_device(self, publickey):
         print(f'Trying to create device: {publickey}')
-        body = {}
-        body['pubkey'] = publickey
-        body['hijack_dns'] = self._wg_hijack_dns
+        body = {
+            'pubkey': publickey,
+            'hijack_dns': self._wg_hijack_dns,
+        }
         try:
             response = self.api('https://api.mullvad.net/accounts/v1/devices', body)
-            print(f'Device created: ({response['name']}) {response['pubkey']}')
+            print(f'Device created: ({response["name"]}) {response["pubkey"]}')
             return response
         except urllib.error.HTTPError as e:
-            error_message = json.loads(e.read())
+            error_message = json.load(e)
             _code = error_message.get('code')
             _message = error_message.get('detail')
             if _message:
@@ -182,8 +182,8 @@ class Mullvad:
         try:
             req = urllib.request.Request('https://api.mullvad.net/public/relays/wireguard/v2/')
             req.add_header('Accept-Encoding', 'gzip')
-            response = urllib.request.urlopen(req)
-            data = self.get_response(response)
+            with urllib.request.urlopen(req) as response:
+                data = self.get_response(response)
             return data['wireguard']
         except urllib.error.HTTPError as e:
             error_message = self.get_response(e)
@@ -194,20 +194,20 @@ class Mullvad:
         try:
             req = urllib.request.Request('https://api.mullvad.net/www/relays/all')
             req.add_header('Accept-Encoding', 'gzip')
-            response = urllib.request.urlopen(req)
-            data = self.get_response(response)
+            with urllib.request.urlopen(req) as response:
+                data = self.get_response(response)
             return [i for i in data if i['type'] == 'wireguard']
         except urllib.error.HTTPError as e:
             error_message = self.get_response(e)
             print(error_message)
             sys.exit(1)
 
-    def filter(self, data, _filter):
+    def filter(self, data: list, _filter) -> list:
         if _filter:
-            return [d for d in data if _filter in d['hostname']]
+            return [d for d in data if d['hostname'].startswith(_filter)]
         return data
 
-    def create_wg_configs(self, device, privatekey, multihop_server):
+    def create_wg_configs(self, device, privatekey, multihop_server) -> None:
         wg = self.get_wireguard_info()
         output_dir = pathlib.Path(self._output_dir).expanduser()
         output_dir.mkdir(exist_ok=True, parents=True)
@@ -222,65 +222,61 @@ class Mullvad:
             config.set('Interface', 'dns', ','.join([wg['ipv4_gateway'], wg['ipv6_gateway']]))
         config.add_section('Peer')
 
+        relays = self.filter(self.get_multihop_info(), self._filter)
+        if not relays:
+            print(f'No relays matching filter: {self._filter}')
+            return
+
+        print(f'Creating files in: {output_dir}')
+        for relay in relays:
+            self.create_wg_config(config, relay, multihop_server)
+
+    def create_wg_config(self, config, relay, multihop_server=None) -> None:
+        output_dir = pathlib.Path(self._output_dir).expanduser()
+        _hostname = relay['hostname']
         if multihop_server:
-            _servername = multihop_server["hostname"]
-            relays = self.filter(self.get_multihop_info(), self._filter)
-            if relays:
-                print(f'Creating files in: {output_dir}')
-                for relay in relays:
-                    _hostname = relay['hostname']
-                    _filepath = pathlib.Path.joinpath(output_dir, f'{_hostname}-via-{_servername}.conf')
-                    _filepath.touch(mode=0o600, exist_ok=True)
-                    with _filepath.open('w') as _file:
-                        config.set('Peer', '#owned', str(relay['owned']))
-                        config.set('Peer', '#provider', relay['provider'])
-                        config.set('Peer', 'publickey', relay['pubkey'])
-                        config.set('Peer', 'allowedips', '0.0.0.0/0,::/0')
-                        if self._wg_relay_ipv6:
-                            wg_relay_address = multihop_server['ipv6_addr_in']
-                        else:
-                            wg_relay_address = multihop_server['ipv4_addr_in']
-                        config.set('Peer', 'endpoint', f'{wg_relay_address}:{relay["multihop_port"]}')
-                        config.write(_file)
-            else:
-                print(f'No relays matching filter: {self._filter}')
+            _servername = multihop_server['hostname']
+            _filepath = pathlib.Path.joinpath(output_dir, f'{_hostname}-via-{_servername}.conf')
         else:
-            relays = self.filter(wg['relays'], self._filter)
-            if relays:
-                print(f'Creating files in: {output_dir}')
-                for relay in relays:
-                    _hostname = relay['hostname']
-                    _filepath = pathlib.Path.joinpath(output_dir, f'{_hostname}.conf')
-                    _filepath.touch(mode=0o600, exist_ok=True)
-                    with _filepath.open('w') as _file:
-                        config.set('Peer', '#owned', str(relay['owned']))
-                        config.set('Peer', '#provider', relay['provider'])
-                        config.set('Peer', 'publickey', relay['public_key'])
-                        config.set('Peer', 'allowedips', '0.0.0.0/0,::/0')
-                        if self._wg_relay_ipv6:
-                            wg_relay_address = relay['ipv6_addr_in']
-                        else:
-                            wg_relay_address = relay['ipv4_addr_in']
-                        config.set('Peer', 'endpoint', f'{wg_relay_address}:{self._wg_relay_port}')
-                        config.write(_file)
-            else:
-                print(f'No relays matching filter: {self._filter}')
+            _filepath = pathlib.Path.joinpath(output_dir, f'{_hostname}.conf')
+
+        _filepath.touch(mode=0o600, exist_ok=True)
+
+        if multihop_server:
+            remote_server = multihop_server
+            remote_port = relay['multihop_port']
+        else:
+            remote_server = relay
+            remote_port = self._wg_relay_port
+
+        if self._wg_relay_ipv6:
+            wg_relay_address = remote_server['ipv6_addr_in']
+        else:
+            wg_relay_address = remote_server['ipv4_addr_in']
+
+        with _filepath.open('w') as _file:
+            config.set('Peer', '#owned', str(relay['owned']))
+            config.set('Peer', '#provider', relay['provider'])
+            config.set('Peer', 'publickey', relay['pubkey'])
+            config.set('Peer', 'allowedips', '0.0.0.0/0,::/0')
+            config.set('Peer', 'endpoint', f'{wg_relay_address}:{remote_port}')
+            config.write(_file)
 
 
-def validate_account(value):
+def validate_account(value: str) -> str:
     if not value.isdigit():
-        raise argparse.ArgumentTypeError("The string must contain only numbers.")
+        raise argparse.ArgumentTypeError('The string must contain only numbers.')
     return value
 
 
-def validate_port(value):
+def validate_port(value: str) -> int:
     try:
         port = int(value)
-    except ValueError:
-        raise argparse.ArgumentTypeError(f"Port must be an integer, but got '{value}'.")
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(f'Port must be an integer, but got \'{value}\'.') from e
 
     if port < 1 or port > 65535:
-        raise argparse.ArgumentTypeError("Port number must be between 1 and 65535.")
+        raise argparse.ArgumentTypeError('Port number must be between 1 and 65535.')
     return port
 
 
@@ -302,14 +298,14 @@ def main():
         default='~/.config/mullvad/wg0', help='directory to write settings')
     parser.add_argument(
         '--wg-relay-port', dest='wg_relay_port', action='store', type=validate_port,
-        default=51820, help='use custom port for relays in wireguard configs')
+        default=51820, help='use custom port for relays in WireGuard configs')
     parser.add_argument(
         '--dns', dest='wg_dns', action='store', nargs='+', type=ipaddress.ip_address,
-        help='use custom dns server in wireguard configs')
+        help='use custom dns server in WireGuard configs')
     parser.add_argument(
         '--hijack-dns', dest='wg_hijack_dns', help='activate hijack dns when creating device', action='store_true')
     parser.add_argument(
-        '--ipv6', dest='wg_relay_ipv6', help='use ipv6 address for relays in wireguard configs', action='store_true')
+        '--ipv6', dest='wg_relay_ipv6', help='use ipv6 address for relays in WireGuard configs', action='store_true')
     parser.add_argument(
         '--multihop-server', dest='wg_multihop_server', action='store', default=None, help='use multihop server')
     parser.add_argument(

--- a/wg-mullvad.py
+++ b/wg-mullvad.py
@@ -14,6 +14,7 @@ import urllib.request
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 
+
 _version = '1.1.3'
 
 

--- a/wg-mullvad.py
+++ b/wg-mullvad.py
@@ -57,7 +57,7 @@ class MullvadApi:
         return self._api(f'{MullvadApi.HOST}/accounts/v1/devices')
 
     @functools.cached_property
-    def web_token(self):
+    def web_token(self) -> str:
         body = {
             'account_number': self.account_number,
         }

--- a/wg-mullvad.py
+++ b/wg-mullvad.py
@@ -265,7 +265,7 @@ class Mullvad:
         if not self._wg_multihop_server:
             return None
 
-        multihop_servers = [r for r in MullvadApi.wireguard_relays() if r == self._wg_multihop_server]
+        multihop_servers = [r for r in MullvadApi.all_wireguard_relays() if r == self._wg_multihop_server]
         if len(multihop_servers) == 1:
             return multihop_servers[0]
         elif len(multihop_servers) >= 1:

--- a/wg-mullvad.py
+++ b/wg-mullvad.py
@@ -283,7 +283,7 @@ def validate_port(value: str) -> int:
 def main():
     parser = argparse.ArgumentParser(
             description=f'{__file__}',
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     required = parser.add_argument_group('required arguments')
     required.add_argument(


### PR DESCRIPTION
# Changes
* Add the following criteria for filtering criteria:
    * `active`: only select relays that are active/online
    * `owned`: only select relays that are owned by Mullvad
    * `stboot`: only select relays that has system transparency (`stboot`/diskless) enabled
    * `min-network-port-speed`: only select relays with network speed in Gbps >= the value passed in
* Hard code the default Mullvad DNS server.
    * It seems like those addresses are fixed, no need to make one extra API calls to get them